### PR TITLE
Add support of Input data layer

### DIFF
--- a/assets/js/netscope.js
+++ b/assets/js/netscope.js
@@ -16139,6 +16139,7 @@ module.exports = Analyzer = class Analyzer {
       d.chIn = parent != null ? parent.chOut : void 0;
       switch (layertype) {
         case "data":
+        case "input":
           //dimensions
           if (((ref2 = n.attribs.input_param) != null ? ref2.shape : void 0) != null) {
             shape = n.attribs.input_param.shape;

--- a/src/analyzer.coffee
+++ b/src/analyzer.coffee
@@ -27,7 +27,7 @@ module.exports =
             d.hIn  = parent?.hOut
             d.chIn = parent?.chOut
             switch layertype
-                when "data"
+                when "data", "input"
                     #dimensions
                     if n.attribs.input_param?.shape?
                         shape     = n.attribs.input_param.shape


### PR DESCRIPTION
In deploy versions of networks `Input` layer is often used as input instead of `Data`.
Now to view networks with `Input` layer is inconvenient: user should replace it with `Data` in his deploy prototxt.

Example:
```json
layer {
  name: "data"
  type: "Input"
  top: "data"
  input_param { shape: { dim: 1 dim: 3 dim: 320 dim: 544 } }
}
```